### PR TITLE
[WIP] make tmsc work with git-based modelforge and sourced.ml

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-ast2vec>=0.3.8-alpha
+sourced-ml==0.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 sourced-ml==0.5.1
+ast2vec>=0.3.8-alpha

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     },
     keywords=["machine learning on source code", "topic modeling",
               "github", "bblfsh", "babelfish"],
-    install_requires=["sourced-ml>=0.5.1"],
+    install_requires=["sourced-ml>=0.5.1", "ast2vec>=0.3.8-alpha"],
     package_data={"": ["LICENSE.md", "README.md"]},
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,8 @@ setup(
         "console_scripts": ["tmsc=tmsc.__main__:main"],
     },
     keywords=["machine learning on source code", "topic modeling",
-              "github", "bblfsh", "babelfish", "ast2vec"],
-    install_requires=["ast2vec>=0.3.8-alpha"],
+              "github", "bblfsh", "babelfish"],
+    install_requires=["sourced-ml>=0.5.1"],
     package_data={"": ["LICENSE.md", "README.md"]},
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/tmsc/__main__.py
+++ b/tmsc/__main__.py
@@ -57,7 +57,7 @@ def main():
 
     args.topics = Topics(log_level=args.log_level).load(source=args.topics, backend=backend) #source=args.topics
     args.df = DocumentFrequencies(log_level=args.log_level).load(source=args.df, backend=backend)
-    args.bow = BOW(log_level=args.log_level).load(source=args.bow, backend=backend)
+    #args.bow = BOW(log_level=args.log_level).load(source=args.bow, backend=backend)
 
     sr = TopicDetector(
         topics=args.topics, docfreq=args.df, bow=args.bow, verbosity=args.log_level,

--- a/tmsc/__main__.py
+++ b/tmsc/__main__.py
@@ -3,13 +3,13 @@ import json
 import logging
 import sys
 
-from ast2vec import Topics, DocumentFrequencies, DEFAULT_BBLFSH_TIMEOUT
-from ast2vec.bow import BOWBase
+from sourced.ml.models import BOW, Topics, DocumentFrequencies
 from modelforge.backends import create_backend
 
 from tmsc.environment import initialize
 from tmsc.topic_detector import TopicDetector
 
+DEFAULT_BBLFSH_TIMEOUT = 10
 
 def main():
     parser = argparse.ArgumentParser()
@@ -52,7 +52,7 @@ def main():
         args.df = DocumentFrequencies(log_level=args.log_level).load(
             source=args.df, backend=backend)
     if args.bow is not None:
-        args.bow = BOWBase(log_level=args.log_level).load(source=args.bow, backend=backend)
+        args.bow = BOW(log_level=args.log_level).load(source=args.bow, backend=backend)
     sr = TopicDetector(
         topics=args.topics, docfreq=args.df, bow=args.bow, verbosity=args.log_level,
         prune_df_threshold=args.prune_df, gcs_bucket=args.gcs, repo2bow_kwargs={

--- a/tmsc/__main__.py
+++ b/tmsc/__main__.py
@@ -2,14 +2,16 @@ import argparse
 import json
 import logging
 import sys
+import os
 
 from sourced.ml.models import BOW, Topics, DocumentFrequencies
 from modelforge.backends import create_backend
+from modelforge.index import GitIndex
 
 from tmsc.environment import initialize
 from tmsc.topic_detector import TopicDetector
 
-DEFAULT_BBLFSH_TIMEOUT = 10
+DEFAULT_BBLFSH_TIMEOUT = 20
 
 def main():
     parser = argparse.ArgumentParser()
@@ -33,6 +35,10 @@ def main():
     parser.add_argument("--prune-df", default=20, type=int,
                         help="Minimum number of times an identifer must occur in different "
                              "documents to be taken into account.")
+    parser.add_argument("--index_repo", default="https://github.com/src-d/models",
+                        help="Models index repository.")
+    parser.add_argument("--index_cache", default=os.path.join(BOW.cache_dir(), "models"),
+                        help="Local cache of models index repository")
     parser.add_argument("-n", "--nnn", default=10, type=int,
                         help="Number of topics to print.")
     parser.add_argument("-f", "--format", default="human", choices=["json", "human"],
@@ -42,24 +48,26 @@ def main():
     if args.linguist is None:
         args.linguist = "./enry"
     initialize(args.log_level, enry=args.linguist)
+
     if args.gcs:
         backend = create_backend(args="bucket=" + args.gcs)
     else:
-        backend = create_backend()
-    if args.topics is not None:
-        args.topics = Topics(log_level=args.log_level).load(source=args.topics, backend=backend)
-    if args.df is not None:
-        args.df = DocumentFrequencies(log_level=args.log_level).load(
-            source=args.df, backend=backend)
-    if args.bow is not None:
-        args.bow = BOW(log_level=args.log_level).load(source=args.bow, backend=backend)
+        git_index = GitIndex(index_repo=args.index_repo, cache=args.index_cache, log_level=args.log_level)
+        backend = create_backend(git_index=git_index)
+
+    args.topics = Topics(log_level=args.log_level).load(source=args.topics, backend=backend) #source=args.topics
+    args.df = DocumentFrequencies(log_level=args.log_level).load(source=args.df, backend=backend)
+    args.bow = BOW(log_level=args.log_level).load(source=args.bow, backend=backend)
+
     sr = TopicDetector(
         topics=args.topics, docfreq=args.df, bow=args.bow, verbosity=args.log_level,
-        prune_df_threshold=args.prune_df, gcs_bucket=args.gcs, repo2bow_kwargs={
+        prune_df_threshold=args.prune_df, repo2bow_kwargs={
             "linguist": args.linguist,
             "bblfsh_endpoint": args.bblfsh,
             "timeout": args.timeout})
+
     topics = sr.query(args.input, size=args.nnn)
+    
     if args.format == "json":
         json.dump({"repository": args.input, "topics": topics}, sys.stdout)
     elif args.format == "human":

--- a/tmsc/environment.py
+++ b/tmsc/environment.py
@@ -1,7 +1,6 @@
 import logging
 
 from modelforge.logs import setup_logging
-from ast2vec import ensure_bblfsh_is_running_noexc, install_enry
 
 
 __initialized__ = False
@@ -22,6 +21,6 @@ def initialize(log_level=logging.INFO, enry="./enry"):
     if __initialized__:
         return
     setup_logging(log_level)
-    ensure_bblfsh_is_running_noexc()
-    install_enry(target=enry, warn_exists=False)
+#    ensure_bblfsh_is_running_noexc()
+#    install_enry(target=enry, warn_exists=False)
     __initialized__ = True

--- a/tmsc/topic_detector.py
+++ b/tmsc/topic_detector.py
@@ -72,21 +72,22 @@ class TopicDetector:
         if size > len(self._topics):
             raise ValueError("size may not be greater than the number of topics - %d" %
                              len(self._topics))
+        token_vector = None
         if self._bow:
             try:
-                repo_index = self._bow.repository_index_by_name( #TODO
+                repo_index = self._bow.documents_index(
                     url_or_path_or_name)
             except KeyError:
                 match = self.GITHUB_URL_RE.match(url_or_path_or_name)
                 if match:
                     name = match.group(2)
                     try:
-                        repo_index = self._bow.repository_index_by_name(name) #TODO
+                        repo_index = self._bow.documents_index(name)
                     except KeyError:
                         pass
             if repo_index:
                 token_vector = self._bow.matrix[repo_index]
-        
+
         if not token_vector:
             if not self._docfreq:
                 raise ValueError("You need to specify document frequencies model to process "

--- a/tmsc/topic_detector.py
+++ b/tmsc/topic_detector.py
@@ -1,9 +1,11 @@
 import logging
 import re
 
-from ast2vec import Topics, Repo2Base, DocumentFrequencies
-from ast2vec.bow import BOWBase
+from sourced.ml.models import BOW, Topics, DocumentFrequencies
+
+from ast2vec import Repo2Base
 from ast2vec.model2.uast2bow import Uasts2BOW
+
 from modelforge.backends import create_backend
 import numpy
 from scipy.sparse import csr_matrix
@@ -15,7 +17,7 @@ class Repo2BOW(Repo2Base):
     """
     Implements the step repository -> :class:`ast2vec.nbow.NBOW`.
     """
-    MODEL_CLASS = BOWBase
+    MODEL_CLASS = BOW
 
     def __init__(self, vocabulary, docfreq, **kwargs):
         super().__init__(**kwargs)
@@ -62,7 +64,7 @@ class TopicDetector:
             self._docfreq = self._docfreq.prune(prune_df_threshold)
         self._log.info("Loaded docfreq model: %s", self._docfreq)
         if bow is not None:
-            assert isinstance(bow, BOWBase)
+            assert isinstance(bow, BOW)
             self._bow = bow
             if self._topics.matrix.shape[1] != self._bow.matrix.shape[1]:
                 raise ValueError("Models do not match: topics has %s tokens while bow has %s" %

--- a/tmsc/topic_detector.py
+++ b/tmsc/topic_detector.py
@@ -1,13 +1,15 @@
 import logging
+import sys
 import re
 
-from ast2vec import Repo2Base
-#from ast2vec.model2.uast2bow import Uasts2BOW #?replace \w sourced.ml
-
-from sourced.ml.models import BOW, Topics, DocumentFrequencies
+# compatibility with old ast2vec version that depends on old modelforge
+sys.modules["modelforge.generate_meta"] = None
+sys.modules["modelforge.model.write_model"] = None
 
 import numpy
 from scipy.sparse import csr_matrix
+from ast2vec.repo2.base import Repo2Base
+from sourced.ml.models import BOW, Topics, DocumentFrequencies
 
 from tmsc.environment import initialize
 from tmsc.uast2bow import Uasts2BOW

--- a/tmsc/uast2bow.py
+++ b/tmsc/uast2bow.py
@@ -1,0 +1,55 @@
+from collections import defaultdict
+import marshal
+import math
+import types
+
+from sourced.ml.models import BOW, DocumentFrequencies
+from sourced.ml.algorithms.uast_ids_to_bag import UastIds2Bag
+
+class Uasts2BOW:
+    def __init__(self, vocabulary: dict, docfreq: DocumentFrequencies,
+                 getter: callable):
+        self._docfreq = docfreq
+        self._uast2bag = UastIds2Bag(vocabulary) #TODO replace with sourced.ml.
+        self._reverse_vocabulary = [None] * len(vocabulary)
+        for key, val in vocabulary.items():
+            self._reverse_vocabulary[val] = key
+        self._getter = getter
+
+    @property
+    def vocabulary(self):
+        return self._uast2bag.token2index #.vocabulary
+
+    @property
+    def docfreq(self):
+        return self._docfreq
+
+    def __call__(self, file_uast_generator):
+        freqs = defaultdict(int)
+        for file_uast in file_uast_generator:
+            bag = self._uast2bag(self._getter(file_uast)) #.uast_to_bag
+            for key, freq in bag.items():
+                freqs[key] += freq
+        missing = []
+        for key, val in freqs.items():
+            try:
+                freqs[key] = math.log(1 + val) * math.log(
+                    self._docfreq.docs / self._docfreq[self._reverse_vocabulary[key]])
+            except KeyError:
+                missing.append(key)
+        for key in missing:
+            del freqs[key]
+        return dict(freqs)
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        if isinstance(self._getter, types.FunctionType) \
+                and self._getter.__name__ == (lambda: None).__name__:
+            assert self._getter.__closure__ is None
+            state["_getter"] = marshal.dumps(self._getter.__code__)
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__ = state
+        if isinstance(self._getter, bytes):
+            self._getter = types.FunctionType(marshal.loads(self._getter), globals())


### PR DESCRIPTION
This is one afternoon attempt to make tmsc great again.

It's WIP as usage of BOW model from modelforge should be removed as per discussion in https://github.com/src-d/models/issues/11

Early feedback is warmly appreciated though, helping to make it ready to merge at some point.

Current version is able to run and produce results:
```
$python3 -m tmsc https://github.com/apache/spark

                Parallel and distributed processing - General IT	4.49
                Machine Learning, sklearn-like APIs - General IT	3.88
               Java/JS + async + JSON serialization - General IT	3.77
                            Cryptography: libraries - General IT	3.23
                        SQL, working with databases - General IT	3.18
                Java string input/output - Programming languages	3.16
                          Java: Spring, Hibernate - Technologies	3.11
                              Operations on numbers - General IT	3.02
                               Distributed clusters - General IT	2.69
           Functional programming, Scala - Programming languages	2.64
```

Full log
<details>

```
$ python3 -m tmsc https://github.com/apache/spark

/usr/local/Cellar/python3/3.6.3/Frameworks/Python.framework/Versions/3.6/lib/python3.6/runpy.py:125: RuntimeWarning: 'tmsc.__main__' found in sys.modules after import of package 'tmsc', but prior to execution of 'tmsc.__main__'; this may result in unpredictable behaviour
  warn(RuntimeWarning(msg))
INFO:GitIndex:Index is cached
INFO:topics:Reading /Users/alex/.source{d}/topics/default.asdf...
INFO:docfreq:Reading /Users/alex/.source{d}/docfreq/default.asdf...
INFO:docfreq:Building the docfreq dictionary...
INFO:topic_detector:Loaded topics model: {'created_at': datetime.datetime(2017, 9, 18, 12, 27, 56, 74233),
 'dependencies': [{'created_at': datetime.datetime(2017, 6, 19, 9, 59, 14, 766638),
                   'dependencies': [],
                   'model': 'docfreq',
                   'uuid': 'f64bacd4-67fb-4c64-8382-399a8e7db52a',
                   'version': [1, 0, 0]}],
 'model': 'topics',
 'uuid': 'c70a7514-9257-4b33-b468-27a8588d4dfa',
 'version': [0, 3, 0]}
320 topics, 2015336 tokens
First 10 tokens: ['ulcancel', 'domainlin', 'trudi', 'fncreateinstancedbaselin', 'wbnz', 'lmultiplicand', 'otronumero', 'qxln', 'gvgq', 'polaroidish']
Topics: labeled, first 10: ['Zend framework, Magento - Technologies', 'AngularJS, promises - Technologies', 'Drupal - Technologies', 'HTML DOM - General IT', 'Cryptography: ciphers and certificates - General IT', 'HTML tags - General IT', 'Countries, Moodle - Technologies', '3D modelling and rendering, WebGL - Technologies', 'POSIX terminal interface, serial interface, image capture - General IT', 'Popular Wordpress plugins - Technologies']
non-zero elements: 16892389  (0.026194)
INFO:docfreq:Pruning to min 20 occurrences
INFO:docfreq:Size: 5720096 -> 416370
INFO:topic_detector:Loaded docfreq model: {'created_at': datetime.datetime(2017, 6, 19, 9, 59, 14, 766638),
 'dependencies': [],
 'model': 'docfreq',
 'uuid': 'f64bacd4-67fb-4c64-8382-399a8e7db52a',
 'version': [1, 0, 0]}
Number of words: 416370
Random 10 words: {'aaa': 6322, 'aaaa': 2676, 'aaaaa': 861, 'aaaaaa': 1163, 'aaaaaaa': 341, 'aaaaaaaa': 156, 'aaaaaaaaa': 119, 'aaaaaaaaaa': 189, 'aaaaaaaaaaa': 30, 'aaaaaaaaaaaa': 90}
Number of documents: 112273
INFO:bblfsh:Detected bblfsh server: 0.0.0.0:9432
WARNING:topic_detector:No BOW cache was loaded.
INFO:repo_cloner:Cloning from https://github.com/apache/spark...
INFO:repo_cloner:Finished cloning https://github.com/apache/spark
INFO:repo_cloner:Classifying the files...
INFO:repo_cloner:Result: {'ANTLR': 1, 'Batchfile': 19, 'C': 1, 'CSS': 6, 'CSV': 20, 'Csound': 3, 'Dockerfile': 3, 'HTML': 4, 'Java': 760, 'JavaScript': 16, 'Makefile': 2, 'Markdown': 4, 'PLSQL': 23, 'PLpgSQL': 62, 'PowerShell': 1, 'Python': 126, 'R': 68, 'RMarkdown': 1, 'Roff': 4, 'SQL': 158, 'SQLPL': 52, 'Scala': 2803, 'Shell': 77, 'Text': 260, 'Thrift': 2, 'reStructuredText': 6}
INFO:repo2bow:Fetching and processing UASTs...
INFO:repo2bow:https://github.com/apache/spark pending tasks: 880
INFO:repo2bow:https://github.com/apache/spark pending tasks: 872
INFO:repo2bow:https://github.com/apache/spark pending tasks: 864
INFO:repo2bow:https://github.com/apache/spark pending tasks: 856
INFO:repo2bow:https://github.com/apache/spark pending tasks: 848
INFO:repo2bow:https://github.com/apache/spark pending tasks: 840
INFO:repo2bow:https://github.com/apache/spark pending tasks: 832
INFO:repo2bow:https://github.com/apache/spark pending tasks: 824
INFO:repo2bow:https://github.com/apache/spark pending tasks: 816
INFO:repo2bow:https://github.com/apache/spark pending tasks: 808
INFO:repo2bow:https://github.com/apache/spark pending tasks: 800
INFO:repo2bow:https://github.com/apache/spark pending tasks: 792
INFO:repo2bow:https://github.com/apache/spark pending tasks: 784
INFO:repo2bow:https://github.com/apache/spark pending tasks: 776
INFO:repo2bow:https://github.com/apache/spark pending tasks: 768
INFO:repo2bow:https://github.com/apache/spark pending tasks: 760
INFO:repo2bow:https://github.com/apache/spark pending tasks: 752
INFO:repo2bow:https://github.com/apache/spark pending tasks: 744
INFO:repo2bow:https://github.com/apache/spark pending tasks: 736
INFO:repo2bow:https://github.com/apache/spark pending tasks: 728
INFO:repo2bow:https://github.com/apache/spark pending tasks: 720
INFO:repo2bow:https://github.com/apache/spark pending tasks: 712
INFO:repo2bow:https://github.com/apache/spark pending tasks: 704
INFO:repo2bow:https://github.com/apache/spark pending tasks: 696
INFO:repo2bow:https://github.com/apache/spark pending tasks: 688
INFO:repo2bow:https://github.com/apache/spark pending tasks: 680
INFO:repo2bow:https://github.com/apache/spark pending tasks: 672
INFO:repo2bow:https://github.com/apache/spark pending tasks: 664
INFO:repo2bow:https://github.com/apache/spark pending tasks: 656
INFO:repo2bow:https://github.com/apache/spark pending tasks: 648
INFO:repo2bow:https://github.com/apache/spark pending tasks: 640
INFO:repo2bow:https://github.com/apache/spark pending tasks: 632
INFO:repo2bow:https://github.com/apache/spark pending tasks: 624
INFO:repo2bow:https://github.com/apache/spark pending tasks: 616
INFO:repo2bow:https://github.com/apache/spark pending tasks: 608
INFO:repo2bow:https://github.com/apache/spark pending tasks: 600
INFO:repo2bow:https://github.com/apache/spark pending tasks: 592
INFO:repo2bow:https://github.com/apache/spark pending tasks: 584
INFO:repo2bow:https://github.com/apache/spark pending tasks: 576
INFO:repo2bow:https://github.com/apache/spark pending tasks: 568
INFO:repo2bow:https://github.com/apache/spark pending tasks: 560
INFO:repo2bow:https://github.com/apache/spark pending tasks: 552
INFO:repo2bow:https://github.com/apache/spark pending tasks: 544
INFO:repo2bow:https://github.com/apache/spark pending tasks: 536
INFO:repo2bow:https://github.com/apache/spark pending tasks: 528
INFO:repo2bow:https://github.com/apache/spark pending tasks: 520
INFO:repo2bow:https://github.com/apache/spark pending tasks: 512
INFO:repo2bow:https://github.com/apache/spark pending tasks: 504
INFO:repo2bow:https://github.com/apache/spark pending tasks: 496
INFO:repo2bow:https://github.com/apache/spark pending tasks: 488
INFO:repo2bow:https://github.com/apache/spark pending tasks: 480
INFO:repo2bow:https://github.com/apache/spark pending tasks: 472
INFO:repo2bow:https://github.com/apache/spark pending tasks: 464
INFO:repo2bow:https://github.com/apache/spark pending tasks: 456
INFO:repo2bow:https://github.com/apache/spark pending tasks: 448
INFO:repo2bow:https://github.com/apache/spark pending tasks: 440
INFO:repo2bow:https://github.com/apache/spark pending tasks: 432
INFO:repo2bow:https://github.com/apache/spark pending tasks: 424
INFO:repo2bow:https://github.com/apache/spark pending tasks: 416
INFO:repo2bow:https://github.com/apache/spark pending tasks: 408
INFO:repo2bow:https://github.com/apache/spark pending tasks: 400
INFO:repo2bow:https://github.com/apache/spark pending tasks: 392
INFO:repo2bow:https://github.com/apache/spark pending tasks: 384
INFO:repo2bow:https://github.com/apache/spark pending tasks: 376
INFO:repo2bow:https://github.com/apache/spark pending tasks: 368
INFO:repo2bow:https://github.com/apache/spark pending tasks: 360
INFO:repo2bow:https://github.com/apache/spark pending tasks: 352
INFO:repo2bow:https://github.com/apache/spark pending tasks: 344
INFO:repo2bow:https://github.com/apache/spark pending tasks: 336
INFO:repo2bow:https://github.com/apache/spark pending tasks: 328
INFO:repo2bow:https://github.com/apache/spark pending tasks: 320
INFO:repo2bow:https://github.com/apache/spark pending tasks: 312
WARNING:repo2bow:/var/folders/rx/z9zyr71d70x92zwbn3rrjx4c0000gn/T/repo2-0hkgj3su/apache&spark_github.com/sql/hive-thriftserver/src/gen/java/org/apache/hive/service/cli/thrift/TCLIService.java was skipped: it is too big - 516093 bytes
INFO:repo2bow:https://github.com/apache/spark pending tasks: 304
INFO:repo2bow:https://github.com/apache/spark pending tasks: 296
INFO:repo2bow:https://github.com/apache/spark pending tasks: 288
INFO:repo2bow:https://github.com/apache/spark pending tasks: 280
INFO:repo2bow:https://github.com/apache/spark pending tasks: 272
INFO:repo2bow:https://github.com/apache/spark pending tasks: 264
INFO:repo2bow:https://github.com/apache/spark pending tasks: 256
INFO:repo2bow:https://github.com/apache/spark pending tasks: 248
INFO:repo2bow:https://github.com/apache/spark pending tasks: 240
INFO:repo2bow:https://github.com/apache/spark pending tasks: 232
INFO:repo2bow:https://github.com/apache/spark pending tasks: 224
INFO:repo2bow:https://github.com/apache/spark pending tasks: 216
INFO:repo2bow:https://github.com/apache/spark pending tasks: 208
INFO:repo2bow:https://github.com/apache/spark pending tasks: 200
INFO:repo2bow:https://github.com/apache/spark pending tasks: 192
INFO:repo2bow:https://github.com/apache/spark pending tasks: 184
INFO:repo2bow:https://github.com/apache/spark pending tasks: 176
INFO:repo2bow:https://github.com/apache/spark pending tasks: 168
INFO:repo2bow:https://github.com/apache/spark pending tasks: 160
INFO:repo2bow:https://github.com/apache/spark pending tasks: 152
INFO:repo2bow:https://github.com/apache/spark pending tasks: 144
INFO:repo2bow:https://github.com/apache/spark pending tasks: 136
INFO:repo2bow:https://github.com/apache/spark pending tasks: 128
INFO:repo2bow:https://github.com/apache/spark pending tasks: 120
INFO:repo2bow:https://github.com/apache/spark pending tasks: 112
INFO:repo2bow:https://github.com/apache/spark pending tasks: 104
INFO:repo2bow:https://github.com/apache/spark pending tasks: 96
INFO:repo2bow:https://github.com/apache/spark pending tasks: 88
INFO:repo2bow:https://github.com/apache/spark pending tasks: 80
INFO:repo2bow:https://github.com/apache/spark pending tasks: 72
INFO:repo2bow:https://github.com/apache/spark pending tasks: 64
INFO:repo2bow:https://github.com/apache/spark pending tasks: 56
INFO:repo2bow:https://github.com/apache/spark pending tasks: 48
WARNING:repo2bow:/var/folders/rx/z9zyr71d70x92zwbn3rrjx4c0000gn/T/repo2-0hkgj3su/apache&spark_github.com/python/pyspark/sql/tests.py was skipped: it is too big - 270463 bytes
INFO:repo2bow:https://github.com/apache/spark pending tasks: 40
INFO:repo2bow:https://github.com/apache/spark pending tasks: 32
INFO:repo2bow:https://github.com/apache/spark pending tasks: 24
INFO:repo2bow:https://github.com/apache/spark pending tasks: 16
INFO:repo2bow:https://github.com/apache/spark pending tasks: 8
INFO:repo2bow:https://github.com/apache/spark pending tasks: 0
                Parallel and distributed processing - General IT	4.49
                Machine Learning, sklearn-like APIs - General IT	3.88
               Java/JS + async + JSON serialization - General IT	3.77
                            Cryptography: libraries - General IT	3.23
                        SQL, working with databases - General IT	3.18
                Java string input/output - Programming languages	3.16
                          Java: Spring, Hibernate - Technologies	3.11
                              Operations on numbers - General IT	3.02
                               Distributed clusters - General IT	2.69
           Functional programming, Scala - Programming languages	2.64
```
</details>